### PR TITLE
fix error thrown in user spec due to mismatched file names

### DIFF
--- a/client/store/user.spec.js
+++ b/client/store/user.spec.js
@@ -1,7 +1,7 @@
 /* global describe beforeEach afterEach it */
 
 import {expect} from 'chai'
-import {me, logout} from './user'
+import {me, logout} from './userReducer'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import configureMockStore from 'redux-mock-store'

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset='utf-8'>
-    <meta name='viewport' content='width=device-width initial-scale=1.0'>
-    <title>Boilermaker</title>
-    <link rel="stylesheet" href="/style.css" />
-    <script defer src="/bundle.js"></script>
-  </head>
-  <body>
-    <div id="app"></div>
-  </body>
-</html>
 
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width initial-scale=1.0'>
+  <title>Boilermaker</title>
+  <link rel="stylesheet" href="/style.css" />
+  <script defer src="/bundle.js"></script>
+</head>
+
+<body>
+  <div id="app"></div>
+</body>
+
+</html>


### PR DESCRIPTION
User.specs in the had a reference to the a file with the incorrect name. We changed it so that the test specs would pass in Travis. This is an attempt to make sure that Heroku can finally run our app.